### PR TITLE
add early continue for `for of routes` if no startPageEvent

### DIFF
--- a/src/server.tsx
+++ b/src/server.tsx
@@ -49,27 +49,26 @@ forward({
   to: readyToLoadSession,
 });
 
-for (const { component } of routes) {
+routes.forEach(({ component }) => {
   const startPageEvent = getStart(component);
+  if (!startPageEvent) return;
 
-  if (startPageEvent) {
-    const matchedRoute = sample(routesMatched, sessionLoaded).filterMap(
-      ({ routes, query }) => {
-        const route = routes.find(routeWithEvent(startPageEvent));
-        if (route) return { route, query };
-        return undefined;
-      },
-    );
+  const matchedRoute = sample(routesMatched, sessionLoaded).filterMap(
+    ({ routes, query }) => {
+      const route = routes.find(routeWithEvent(startPageEvent));
+      if (route) return { route, query };
+      return undefined;
+    },
+  );
 
-    forward({
-      from: matchedRoute.map(({ route, query }) => ({
-        params: route.match.params,
-        query,
-      })),
-      to: startPageEvent,
-    });
-  }
-}
+  forward({
+    from: matchedRoute.map(({ route, query }) => ({
+      params: route.match.params,
+      query,
+    })),
+    to: startPageEvent,
+  });
+});
 
 sample({
   source: serverStarted,

--- a/src/server.tsx
+++ b/src/server.tsx
@@ -49,9 +49,9 @@ forward({
   to: readyToLoadSession,
 });
 
-routes.forEach(({ component }) => {
+for (const { component } of routes) {
   const startPageEvent = getStart(component);
-  if (!startPageEvent) return;
+  if (!startPageEvent) continue;
 
   const matchedRoute = sample(routesMatched, sessionLoaded).filterMap(
     ({ routes, query }) => {
@@ -68,7 +68,7 @@ routes.forEach(({ component }) => {
     })),
     to: startPageEvent,
   });
-});
+}
 
 sample({
   source: serverStarted,


### PR DESCRIPTION
improved readability a little by removing 1 level of nesting

